### PR TITLE
Fixed PHP notice

### DIFF
--- a/lib/fg/Essence/Essence.php
+++ b/lib/fg/Essence/Essence.php
@@ -141,6 +141,7 @@ class Essence {
 	public function embed( $url, array $options = array( )) {
 
 		$providers = $this->_Collection->providers( $url );
+        $Media = null;
 
 		foreach ( $providers as $Provider ) {
 			try {


### PR DESCRIPTION
Hi Felix,

I encountered a PHP notice that the variable $Media is undefined if Essence::embed() is called and the provider object throws an exception.

I fixed it with this pull request.

Best regards,
MadCatme
