### PR TITLE
Custom providers without namespace requirement

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,6 @@
 vendor
 
+.buildpath
+.settings
+.project
+

--- a/README.md
+++ b/README.md
@@ -123,12 +123,14 @@ $Essence = new fg\Essence\Essence(
 		'OEmbed/Youtube',
 		'OEmbed/Dailymotion',
 		'OpenGraph/Ted',
-		'YourCustomProvider'
+		'\YourCustomProvider'
 	)
 );
 
 ?>
 ```
+
+You can add custom providers by adding a FQCN (Fully-Qualified Class Name) to the list of providers.
 
 When given an array of providers, the constructor might throw an exception if a provider couldn't be found or loaded.
 If you want to make your code rock solid, you should better wrap that up in a try/catch statement:

--- a/lib/fg/Essence/ProviderCollection.php
+++ b/lib/fg/Essence/ProviderCollection.php
@@ -83,7 +83,15 @@ class ProviderCollection {
 				$options = array( );
 			}
 
-			$className = '\\fg\\Essence\\Provider\\' . str_replace( '/', '\\', $name );
+			// check if the given provider name start with a slash
+			// if the first char is a slash a FQCN is given
+			// otherwise we need to transform it into a FQCN relative to the Essence buildin providers namespace
+			if ( substr($name, 0, 1) === '\\' ) {
+			    $className = $name;
+			} else {
+			    $className = '\\fg\\Essence\\Provider\\' . str_replace( '/', '\\', $name );
+			}
+
 			$Reflection = new \ReflectionClass( $className );
 
 			if ( !$Reflection->isAbstract( )) {


### PR DESCRIPTION
Make it easier to add custom providers. There is no longer a namespace requirement.

In the current situation all custom providers must be have the fg\Essence\Provider namespace. When you create (private) custom OEmbed providers it is a good idea to use your own namespace. That makes autoloading en structoring code a lot easier.
