### PR TITLE
Make Essence autoloader not attempt to load non-Essence classes.

### DIFF
--- a/lib/Essence/Utility/Autoload.php
+++ b/lib/Essence/Utility/Autoload.php
@@ -28,6 +28,9 @@ class Autoload {
 		$basePath = rtrim( $basePath, DIRECTORY_SEPARATOR );
 
 		spl_autoload_register( function( $className ) use ( $basePath ) {
+			if (strpos($className, 'Essence\\') === false) {
+				return;
+			}
 			$path = $basePath
 				. DIRECTORY_SEPARATOR
 				. str_replace( '\\', DIRECTORY_SEPARATOR, $className )


### PR DESCRIPTION
Here we make sure that the Essence autoloader only attempts to load classes that
begin with Essence...
