### PR TITLE
Update to Twitter URL pattern.

### DIFF
--- a/lib/providers.php
+++ b/lib/providers.php
@@ -306,7 +306,7 @@ return [
 	],
 	'Twitter' => [
 		'class' => 'OEmbed',
-		'filter' => '#twitter\.com/[a-zA-Z0-9_]+/status/.+#i',
+		'filter' => '#twitter\.com/[a-zA-Z0-9_]+/status(es)?/.+#i',
 		'endpoint' => 'https://api.twitter.com/1/statuses/oembed.json?url=%s'
 	],
 	'Ustream' => [


### PR DESCRIPTION
Currently we only handle URLs like:

```
https://twitter.com/JonathanAquino/status/332855223402000385
```

This patch also allows URLs like:

```
https://twitter.com/JonathanAquino/statuses/332855223402000385
```

which are also valid.
