### PR TITLE
Fix encoding issues with OpenGraph descriptions with older Libxml version.

### DIFF
--- a/lib/Essence/Dom/Parser/Native.php
+++ b/lib/Essence/Dom/Parser/Native.php
@@ -67,6 +67,7 @@ class Native implements Parser {
 	protected function _document( $html ) {
 
 		$reporting = error_reporting( 0 );
+		$html = $this->fixCharset( $html );
 		$Document = DomDocument::loadHTML( $html );
 		error_reporting( $reporting );
 
@@ -75,6 +76,37 @@ class Native implements Parser {
 		}
 
 		return $Document;
+	}
+
+
+
+	/**
+	 *	If necessary, fixes the given HTML's charset to work with the current
+	 *	version of Libxml (used by DomDocument). Older versions of Libxml
+	 *	recognize only
+	 *
+	 *      <META http-equiv="Content-Type" content="text/html; charset=UTF-8">
+	 *
+	 *  from HTML4, and not the new HTML5 form:
+	 *
+	 *      <meta charset="utf-8">
+	 *
+	 *  with the result that parsed strings can have funny characters.
+	 *
+	 *	@param string $html HTML source.
+	 *	@return string the fixed HTML
+	 *	@see "HTML5, character encodings and DOMDocument loadHTML and loadHTMLFile"
+	 *	     http://www.glenscott.co.uk/blog/html5-character-encodings-and-domdocument-loadhtml-and-loadhtmlfile/
+	 */
+
+	protected function fixCharset( $html ) {
+		// The fix is from https://github.com/glenscott/dom-document-charset/blob/master/DOMDocumentCharset.php
+		if ( LIBXML_VERSION < 20800 && stripos($html, 'meta charset') !== false ) {
+			$html = preg_replace( '/<meta charset=["\']?([^"\']+)"/i',
+					              '<meta http-equiv="Content-Type" content="text/html; charset=$1"',
+					              $html );
+		}
+		return $html;
 	}
 
 


### PR DESCRIPTION
There was an encoding issue in the parsing of OpenGraph tags on certain
websites, for PHP with older Libxml versions. For example:

```
XG_App::includeFileOnce('/lib/ext/Essence/bootstrap.php');
$essence = \Essence\Essence::instance( );
$media = $essence->embed( 'http://qz.com/204401' );
echo '<pre>' . qh(var_export(iterator_to_array($media), true));
```

would display some funny characters:

```
sources tell us theÂ filing of itsÂ IPO papers isÂ days, not weeks, away)
```

The problem is that older versions of Libxml recognize only

```
<META http-equiv="Content-Type" content="text/html; charset=UTF-8">
```

from HTML4, and not the new HTML5 form:

```
<meta charset="utf-8">
```

with the result that parsed strings can have funny characters.

The fix is to replace the new form by the old form. For more information, see
"HTML5, character encodings and DOMDocument loadHTML and loadHTMLFile"
http://www.glenscott.co.uk/blog/html5-character-encodings-and-domdocument-loadhtml-and-loadhtmlfile/
