### PR TITLE
Spotify only accepts requests that have an User Agent set

### DIFF
--- a/lib/Essence/Http/Client/Native.php
+++ b/lib/Essence/Http/Client/Native.php
@@ -57,7 +57,9 @@ class Native implements Client {
 	public function get( $url ) {
 
 		$reporting = error_reporting( 0 );
-		$contents = file_get_contents( $url );
+		$options  = array('http' => array('user_agent' => 'Essence/OEmbed'));
+		$context  = stream_context_create($options);
+		$contents = file_get_contents( $url, false, $context );
 		error_reporting( $reporting );
 
 		if ( $contents === false ) {


### PR DESCRIPTION
When using the Native HTTP interface to fetch data, Spotify would not return data unless there was a User Agent set.
