### PR TITLE
Soundcloud usernames

### DIFF
--- a/lib/providers.php
+++ b/lib/providers.php
@@ -284,7 +284,7 @@ return [
 	],
 	'SoundCloud' => [
 		'class' => 'OEmbed',
-		'filter' => '#soundcloud\.com/[a-zA-Z0-9-]+/[a-zA-Z0-9-]+#i',
+		'filter' => '#soundcloud\.com/[a-zA-Z0-9-_]+/[a-zA-Z0-9-]+#i',
 		'endpoint' => 'http://soundcloud.com/oembed?format=json&url=%s'
 	],
 	'SpeakerDeck' => [


### PR DESCRIPTION
SoundCloud allows "_" for usernames, e.g. https://soundcloud.com/kidnap_kid/survive

I have not found any examples where "_" is used for song titles, so I am not changing that part.
