### PR TITLE
Update dailymotion endpoint to https

### DIFF
--- a/lib/Essence/Di/Container/Standard.php
+++ b/lib/Essence/Di/Container/Standard.php
@@ -418,7 +418,7 @@ class Standard extends Container {
 			}),
 			'Dailymotion' => Container::unique(function($C) {
 				return $C->get('OEmbedProvider')->setEndpoint(
-					'http://www.dailymotion.com/services/oembed?format=json&url=:url'
+					'https://www.dailymotion.com/services/oembed?format=json&url=:url'
 				);
 			}),
 			'Deviantart' => Container::unique(function($C) {


### PR DESCRIPTION
This is fix as part of #43. So dailymotion now won't break https pages.