### PR TITLE
readme: fix crawl method name in Extracting URLs example

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ The Essence class provides some useful utility functions to ensure you will get 
 
 ### Extracting URLs
 
-The `crawl()` method lets you crawl extractable URLs from a web page.
+The `crawlUrl()` method lets you crawl extractable URLs from a web page.
 
 For example, here is how you could get the URL of all videos in a blog post:
 

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ The Essence class provides some useful utility functions to ensure you will get 
 
 ### Extracting URLs
 
-The `crawlUrl()` method lets you crawl extractable URLs from a web page.
+The `crawl()` and `crawlUrl()` methods let you crawl extractable URLs from a web page, either directly from its source, or from its URL (in which case Essence will take care of fetching the source).
 
 For example, here is how you could get the URL of all videos in a blog post:
 


### PR DESCRIPTION
Hey,

Just wanted to use the crawl feature of Essence and couldn't figure out why my code wasn't working. I actually read the doc a bit too quickly and used the crawl method instead of the crawlUrl method. Here is a tiny fix in the readme to prevent this.