### PR TITLE
Add permalink.php, photo.php FacebookPost support

### DIFF
--- a/lib/Essence/Di/Container/Standard.php
+++ b/lib/Essence/Di/Container/Standard.php
@@ -735,7 +735,7 @@ class Standard extends Container {
 			'Dotsub' => '~dotsub\.com/view/.+~i',
 			'EdocrOEmbed' => '~edocr\.com/doc/[0-9]+/.+~i',
 			'EdocrTwitterCards' => '~edocr\.com/doc/[0-9]+/.+~i',
-			'FacebookPost' => '~facebook\.com\/[\S]+\/(photos|posts).+~i',
+			'FacebookPost' => '~facebook\.com\/([\S]+\/)?(photos|posts|photo\.php|permalink\.php).+~i',
 			'FlickrOEmbed' => '~flickr\.com/photos/[a-zA-Z0-9@\._]+/[0-9]+~i',
 			'FlickrOpenGraph' => '~flickr\.com/photos/[a-zA-Z0-9@\._]+/[0-9]+~i',
 			'FunnyOrDie' => '~funnyordie\.com/videos/.+~i',


### PR DESCRIPTION
Add FacebookPost support for url like photo.php and permalink.php
Examples:
https://www.facebook.com/photo.php?fbid=2071641476382993&set=a.1546936945520118.1073741829.100006114824847&type=3&theater

https://www.facebook.com/permalink.php?story_fbid=457794347977739&id=100012415323608