### PR TITLE
Add Libsyn special provider

### DIFF
--- a/lib/Essence/Di/Container/Standard.php
+++ b/lib/Essence/Di/Container/Standard.php
@@ -531,6 +531,11 @@ class Standard extends Container {
 					'http://www.kickstarter.com/services/oembed?format=json&url=:url'
 				);
 			}),
+			'Libsyn' => Container::unique(function($C) {
+				return $C->get('OEmbedProvider')->setEndpoint(
+					'https://oembed.libsyn.com/?url=:url&format=json'
+				);
+			}),
 			'Meetup' => Container::unique(function($C) {
 				return $C->get('OEmbedProvider')->setEndpoint(
 					'https://api.meetup.com/oembed?format=json&url=:url'
@@ -752,6 +757,7 @@ class Standard extends Container {
 			'Jest' => '~jest\.com/(video|embed)/.+~i',
 			'Justin' => '~justin\.tv/.+~i',
 			'Kickstarter' => '~kickstarter\.com/projects/.+~i',
+			'Libsyn' => '~libsyn\.com~i',
 			'Meetup' => '~meetup\.(com|ps)/.+~i',
 			'Mixcloud' => '~mixcloud\.com/.+/.+~i',
 			'Mobypicture' => '~(moby.to|mobypicture\.com/user/.+/view)/.+~i',


### PR DESCRIPTION
For reasons I can't quite discern, Libsyn' oEmbed URL isn't detected as a regular oEmbed provider. This patch adds Libsyn as a registered special provider.

Example Libsyn oEmbed URL: `https://oembed.libsyn.com/embed?item_id=8634992`

Per Libsyn support:

> The url's absolutely do support oEmbed spec correctly - they wouldn't work with Embed.ly otherwise.  You could always try just using the embed code for the player directly in your new site instead of the oEmbed.  Most of the 'testers' out there seem to be looking for the metatags for discovery:  https://oembed.com/#section4 and not actually parsing the response.

Tested with the [oEmbed plugin](https://github.com/wrav/oembed), which uses Essence to render oEmbed in Craft CMS. 

I'd love to understand what is needed to address this as a regular oEmbed provider, but I'm not entirely clear on the meaning of the above. 

I did notice that the Libsyn oEmbed `link` type is `text/json+oembed`, whereas the spec denotes `application/json+oembed`. Essence seems to search specifically for`json` in the `type` field though, from what I can see (in Oembed.php line 214's string filter), which seems like it should work? 

My PHP is a little rusty, so... :) At any rate, this patch seems to work fine, and happy to help test or report to Libsyn why their file isn't working with the default Essence code. 
