### PR TITLE
Add JWPlayer support

### DIFF
--- a/lib/Essence/Di/Container/Standard.php
+++ b/lib/Essence/Di/Container/Standard.php
@@ -17,6 +17,7 @@ use Essence\Http\Client\Native as NativeHttpClient;
 use Essence\Provider\Collection;
 use Essence\Provider\MetaTags;
 use Essence\Provider\OEmbed;
+use Essence\Provider\OEmbed\JWPlayer;
 use Essence\Provider\OpenGraph;
 use Essence\Provider\Preparator\Refactorer;
 use Essence\Provider\Presenter\Completer;
@@ -526,6 +527,9 @@ class Standard extends Container {
 					'http://api.justin.tv/api/embed/from_url.json?url=:url'
 				);
 			}),
+			'JWPlayer' => Container::unique(function($C) {
+				return new JWPlayer($C->get('Http'), $C->get('Dom'));
+			}),
 			'Kickstarter' => Container::unique(function($C) {
 				return $C->get('OEmbedProvider')->setEndpoint(
 					'http://www.kickstarter.com/services/oembed?format=json&url=:url'
@@ -751,6 +755,7 @@ class Standard extends Container {
 			'InstagramOpenGraph' => '~instagr(\.am|am\.com)/.+~i',
 			'Jest' => '~jest\.com/(video|embed)/.+~i',
 			'Justin' => '~justin\.tv/.+~i',
+			'JWPlayer' => '~\.jwplayer.com/.+?/([a-z0-9]+)-([a-z0-9]+)\.~i',
 			'Kickstarter' => '~kickstarter\.com/projects/.+~i',
 			'Meetup' => '~meetup\.(com|ps)/.+~i',
 			'Mixcloud' => '~mixcloud\.com/.+/.+~i',

--- a/lib/Essence/Provider/OEmbed/JWPlayer.php
+++ b/lib/Essence/Provider/OEmbed/JWPlayer.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Essence\Provider\OEmbed;
+
+use Essence\Provider\OEmbed;
+
+class JWPlayer extends OEmbed
+{
+  protected $_endpoint = 'https://cdn.jwplayer.com/v2/media/:mediaId';
+  private $pattern = '~\.jwplayer.com/.+/(?<mediaId>[a-z0-9]+)-(?<playerId>[a-z0-9]+)\.~i';
+  private $mediaId;
+  private $playerId;
+
+
+  /**
+   * {@inheritDoc}
+   *
+   * Sets the endpoint based on the incoming mediaId
+   */
+	protected function _buildConfig($url) {
+    preg_match($this->pattern, $url, $matches);
+    $this->playerId = $matches['playerId'] ? $matches['playerId'] : 'default';
+    $this->mediaId = $matches['mediaId'];
+    $endpoint = str_replace(':mediaId', $this->mediaId, $this->_endpoint);
+		return new Config($endpoint, $this->_format);
+  }
+
+  /**
+   * {@inheritDoc}
+   *
+   * Reformats the JWP Api data to match oEmbed spec
+   */
+  protected function _parse($response, $format) {
+    $parsed = parent::_parse($response, $format);
+    $playlist = $parsed['playlist'][0];
+    $url = sprintf('https://cdn.jwplayer.com/players/%s-%s.html', $this->mediaId, $this->playerId);
+    return [
+      'type' => 'video',
+      'version' => '1.0',
+      'provider_name' => 'JWPlayer',
+      'provider_url' => 'https://www.jwplayer.com/',
+      'title' => $parsed['title'],
+      'description' => $parsed['description'],
+      'html' => sprintf('<iframe src="%s"></iframe>', $url),
+      'thumbnailUrl' => $playlist['image'],
+      'url' => sprintf('%s.html', $url),
+    ];
+	}
+
+}

--- a/lib/Essence/Provider/OEmbed/JWPlayer.php
+++ b/lib/Essence/Provider/OEmbed/JWPlayer.php
@@ -6,45 +6,44 @@ use Essence\Provider\OEmbed;
 
 class JWPlayer extends OEmbed
 {
-  protected $_endpoint = 'https://cdn.jwplayer.com/v2/media/:mediaId';
-  private $pattern = '~\.jwplayer.com/.+/(?<mediaId>[a-z0-9]+)-(?<playerId>[a-z0-9]+)\.~i';
-  private $mediaId;
-  private $playerId;
+	protected $_endpoint = 'https://cdn.jwplayer.com/v2/media/:mediaId';
+	private $pattern = '~\.jwplayer.com/.+/(?<mediaId>[a-z0-9]+)-(?<playerId>[a-z0-9]+)\.~i';
+	private $mediaId;
+	private $playerId;
 
-
-  /**
-   * {@inheritDoc}
-   *
-   * Sets the endpoint based on the incoming mediaId
-   */
+	/**
+	 * {@inheritDoc}
+	 *
+	 * Sets the endpoint based on the incoming mediaId
+	 */
 	protected function _buildConfig($url) {
-    preg_match($this->pattern, $url, $matches);
-    $this->playerId = $matches['playerId'] ? $matches['playerId'] : 'default';
-    $this->mediaId = $matches['mediaId'];
-    $endpoint = str_replace(':mediaId', $this->mediaId, $this->_endpoint);
+		preg_match($this->pattern, $url, $matches);
+		$this->playerId = $matches['playerId'] ? $matches['playerId'] : 'default';
+		$this->mediaId = $matches['mediaId'];
+		$endpoint = str_replace(':mediaId', $this->mediaId, $this->_endpoint);
 		return new Config($endpoint, $this->_format);
-  }
+	}
 
-  /**
-   * {@inheritDoc}
-   *
-   * Reformats the JWP Api data to match oEmbed spec
-   */
-  protected function _parse($response, $format) {
-    $parsed = parent::_parse($response, $format);
-    $playlist = $parsed['playlist'][0];
-    $url = sprintf('https://cdn.jwplayer.com/players/%s-%s.html', $this->mediaId, $this->playerId);
-    return [
-      'type' => 'video',
-      'version' => '1.0',
-      'provider_name' => 'JWPlayer',
-      'provider_url' => 'https://www.jwplayer.com/',
-      'title' => $parsed['title'],
-      'description' => $parsed['description'],
-      'html' => sprintf('<iframe src="%s"></iframe>', $url),
-      'thumbnailUrl' => $playlist['image'],
-      'url' => sprintf('%s.html', $url),
-    ];
+	/**
+	 * {@inheritDoc}
+	 *
+	 * Reformats the JWP Api data to match oEmbed spec
+	 */
+	protected function _parse($response, $format) {
+		$parsed = parent::_parse($response, $format);
+		$playlist = $parsed['playlist'][0];
+		$url = sprintf('https://cdn.jwplayer.com/players/%s-%s.html', $this->mediaId, $this->playerId);
+		return [
+			'type' => 'video',
+			'version' => '1.0',
+			'provider_name' => 'JWPlayer',
+			'provider_url' => 'https://www.jwplayer.com/',
+			'title' => $parsed['title'],
+			'description' => $parsed['description'],
+			'html' => sprintf('<iframe src="%s"></iframe>', $url),
+			'thumbnailUrl' => $playlist['image'],
+			'url' => sprintf('%s.html', $url),
+		];
 	}
 
 }

--- a/tests/e2e/ProvidersTest.php
+++ b/tests/e2e/ProvidersTest.php
@@ -304,6 +304,12 @@ class ProvidersTest extends TestCase {
 				''
 			],*/
 			[
+				'JWPlayer',
+				'https://cdn.jwplayer.com/players/nPripu9l-ALJ3XQCI.js',
+				'title',
+				'Big Buck Bunny Trailer'
+			],
+			[
 				'Kickstarter',
 				'https://www.kickstarter.com/projects/1452363698/good-seed-craft-veggie-burgers',
 				'authorName',


### PR DESCRIPTION
JWPlayer doesn't have a native oEmbed endpoint, but they do have a public JSON api. This PR adds an implementation for JWPlayer to support building out oEmbed data from that API.

[JWPlayer docs](https://developer.jwplayer.com/jw-platform/docs/developer-guide/delivery-api/embedding-players/)
[Example URL](https://cdn.jwplayer.com/players/nPripu9l-ALJ3XQCI.html)