### PR TITLE
HTTP access to the oembed endpoint is no longer allowed

### DIFF
--- a/lib/Essence/Di/Container/Standard.php
+++ b/lib/Essence/Di/Container/Standard.php
@@ -692,7 +692,7 @@ class Standard extends Container {
 			}),
 			'Youtube' => Container::unique(function($C) {
 				return $C->get('YoutubeProvider')->setEndpoint(
-					'http://www.youtube.com/oembed?format=json&url=:url'
+					'https://www.youtube.com/oembed?format=json&url=:url'
 				);
 			}),
 			'FacebookVideo' => Container::unique(function($C) {


### PR DESCRIPTION
The following response is returned:

```json
{
  "error": {
    "code": 403,
    "message": "SSL is required to perform this operation.",
    "status": "PERMISSION_DENIED"
  }
}
```

(with: http://www.youtube.com/oembed?url=https%3A%2F%2Fwww.youtube.com%2Fwatch%3Fv%3Dd2sQiI5NFAM%26list%3DPLV5CVI1eNcJgCrPH_e6d57KRUTiDZgs0u → when opened in browser there is a redirect to `https`, but that does not seem to be the case in the library?)