### PR TITLE
Set Vimeo endpoint to use https to avoid mixed content in response

### DIFF
--- a/lib/Essence/Di/Container/Standard.php
+++ b/lib/Essence/Di/Container/Standard.php
@@ -669,7 +669,7 @@ class Standard extends Container {
 			}),
 			'Vimeo' => Container::unique(function($C) {
 				return $C->get('VimeoProvider')->setEndpoint(
-					'http://vimeo.com/api/oembed.json?url=:url'
+					'https://vimeo.com/api/oembed.json?url=:url'
 				);
 			}),
 			'Vine' => Container::unique(function($C) {


### PR DESCRIPTION
When extracting Vimeo URLs the oEmbed response returns mixed content due to the Vimeo endpoint using the http scheme instead of https.

E.g. when running this command:

```bash
./cli/essence.php extract https://vimeo.com/76979871 
```

Response:

```
thumbnailUrl: http://i.vimeocdn.com/video/452001751_295x166.jpg <<< http
url: https://vimeo.com/76979871 <<< https
```