### PR TITLE
Fix justin.tv Provider

### DIFF
--- a/lib/Essence/Di/Container/Standard.php
+++ b/lib/Essence/Di/Container/Standard.php
@@ -521,7 +521,7 @@ class Standard extends Container {
 					'http://www.jest.com/oembed.json?url=:url'
 				);
 			}),
-			'Justin.tv' => Container::unique(function($C) {
+			'Justin' => Container::unique(function($C) {
 				return $C->get('OEmbedProvider')->setEndpoint(
 					'http://api.justin.tv/api/embed/from_url.json?url=:url'
 				);

--- a/tests/e2e/ProvidersTest.php
+++ b/tests/e2e/ProvidersTest.php
@@ -298,7 +298,7 @@ class ProvidersTest extends TestCase {
 				''
 			],*/
 			/*[
-				'Justin.tv',
+				'Justin',
 				'http://www.justin.tv/deepellumonair',
 				'',
 				''


### PR DESCRIPTION
The filter and the provider of `justin.tv` had different names, so whenever a link matches `justin.tv`  filter, the provider is null.