### PR TITLE
Temporarily suppress error notices in PHP 8.1

### DIFF
--- a/lib/Essence/Media.php
+++ b/lib/Essence/Media.php
@@ -256,6 +256,7 @@ class Media implements IteratorAggregate, JsonSerializable {
 	 *
 	 *	@return ArrayIterator Iterator.
 	 */
+	#[\ReturnTypeWillChange]
 	public function getIterator() {
 		return new ArrayIterator($this->_properties);
 	}

--- a/lib/Essence/Media.php
+++ b/lib/Essence/Media.php
@@ -268,6 +268,7 @@ class Media implements IteratorAggregate, JsonSerializable {
 	 *
 	 *	@return string JSON representation.
 	 */
+	#[\ReturnTypeWillChange]
 	public function jsonSerialize() {
 		return $this->_properties;
 	}


### PR DESCRIPTION
Hello,

my patches prevent to display the following error messages in PHP 8.1:

```
PHP Deprecated: Return type of Essence\Media::getIterator() should either be compatible with IteratorAggregate::getIterator(): Traversable, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in ./vendor/essence/essence/lib/Essence/Media.php:259
PHP Deprecated: Return type of Essence\Media::jsonSerialize() should either be compatible with JsonSerializable::jsonSerialize(): mixed, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in ./vendor/essence/essence/lib/Essence/Media.php:270
```