### PR TITLE
PHP 8.* compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,13 +2,12 @@ language: php
 sudo: false
 
 php:
-  - 5.5
-  - 5.6
+  - 8.0
 
 before_script:
-  - composer install
+  - composer install --dev
 
-script: phpunit --configuration=phpunit.e2e.xml --coverage-clover=coverage.clover
+script: ./vendor/bin/phpunit --configuration=phpunit.e2e.xml --coverage-clover=coverage.clover
 
 after_script:
   - wget https://scrutinizer-ci.com/ocular.phar

--- a/composer.json
+++ b/composer.json
@@ -18,10 +18,13 @@
 	"homepage": "http://github.com/essence/essence",
 	"minimum-stability": "dev",
 	"require": {
-		"php": ">=5.5.0",
+		"php": ">=8.0",
 		"essence/dom": "~1.0.0",
 		"essence/http": "~1.0.0",
 		"fg/parkour": "~1.1.0"
+	},
+	"require-dev": {
+		"phpunit/phpunit": "^9.6"
 	},
 	"suggest": {
 		"ext-curl": "*"

--- a/lib/Essence/Media.php
+++ b/lib/Essence/Media.php
@@ -256,7 +256,7 @@ class Media implements IteratorAggregate, JsonSerializable {
 	 *
 	 *	@return ArrayIterator Iterator.
 	 */
-	public function getIterator() {
+	public function getIterator(): \Iterator {
 		return new ArrayIterator($this->_properties);
 	}
 
@@ -267,7 +267,7 @@ class Media implements IteratorAggregate, JsonSerializable {
 	 *
 	 *	@return string JSON representation.
 	 */
-	public function jsonSerialize() {
+	public function jsonSerialize(): mixed {
 		return $this->_properties;
 	}
 }

--- a/tests/Essence/CrawlerTest.php
+++ b/tests/Essence/CrawlerTest.php
@@ -6,7 +6,7 @@
  */
 namespace Essence;
 
-use PHPUnit_Framework_TestCase as TestCase;
+use PHPUnit\Framework\TestCase as TestCase;
 use Essence\Di\Container\Standard as StandardContainer;
 use Essence\Dom\Document\Factory\Native as NativeDomDocument;
 use Essence\Http\Client\Native as NativeHttpClient;
@@ -29,7 +29,7 @@ class CrawlerTest extends TestCase {
 	/**
 	 *
 	 */
-	public function setUp() {
+	public function setUp(): void {
 		$Container = new StandardContainer();
 		$Container->set('filters', [
 			'Provider' => '~pass~i'

--- a/tests/Essence/Di/ContainerTest.php
+++ b/tests/Essence/Di/ContainerTest.php
@@ -6,7 +6,7 @@
  */
 namespace Essence\Di;
 
-use PHPUnit_Framework_TestCase as TestCase;
+use PHPUnit\Framework\TestCase as TestCase;
 
 
 
@@ -32,7 +32,7 @@ class ContainerTest extends TestCase {
 	/**
 	 *
 	 */
-	public function setUp() {
+	public function setUp(): void {
 		$this->Container = new Container();
 	}
 

--- a/tests/Essence/EssenceTest.php
+++ b/tests/Essence/EssenceTest.php
@@ -6,8 +6,8 @@
  */
 namespace Essence;
 
-use PHPUnit_Framework_TestCase as TestCase;
-use PHPUnit_Framework_Constraint_IsEqual as IsEqual;
+use PHPUnit\Framework\TestCase as TestCase;
+use PHPUnit\Framework\Constraint\IsEqual as IsEqual;
 use Essence\Media;
 use Essence\Http\Client\Native as NativeHttpClient;
 use Essence\Utility\Url;
@@ -88,7 +88,7 @@ class EssenceTest extends TestCase {
 			'/index.php'
 		];
 
-		$Http = $this->getMock('\\Essence\\Http\\Client');
+		$Http = $this->createMock('\\Essence\\Http\\Client');
 
 		$Http
 			->expects($this->once())

--- a/tests/Essence/ExtractorTest.php
+++ b/tests/Essence/ExtractorTest.php
@@ -6,7 +6,7 @@
  */
 namespace Essence;
 
-use PHPUnit_Framework_TestCase as TestCase;
+use PHPUnit\Framework\TestCase as TestCase;
 use Essence\Di\Container\Standard as StandardContainer;
 
 
@@ -26,7 +26,7 @@ class ExtractorTest extends TestCase {
 	/**
 	 *
 	 */
-	public function setUp() {
+	public function setUp(): void {
 		$Media = new Media();
 		$Provider = $this->getMockForAbstractClass('\\Essence\\Provider');
 

--- a/tests/Essence/MediaTest.php
+++ b/tests/Essence/MediaTest.php
@@ -6,7 +6,7 @@
  */
 namespace Essence;
 
-use PHPUnit_Framework_TestCase as TestCase;
+use PHPUnit\Framework\TestCase as TestCase;
 
 
 
@@ -35,7 +35,7 @@ class MediaTest extends TestCase {
 	/**
 	 *
 	 */
-	public function setUp() {
+	public function setUp(): void {
 		$this->Media = new Media($this->properties);
 	}
 

--- a/tests/Essence/Provider/CollectionTest.php
+++ b/tests/Essence/Provider/CollectionTest.php
@@ -6,7 +6,7 @@
  */
 namespace Essence\Provider;
 
-use PHPUnit_Framework_TestCase as TestCase;
+use PHPUnit\Framework\TestCase as TestCase;
 use Essence\Di\Container;
 use StdClass;
 
@@ -34,7 +34,7 @@ class CollectionTest extends TestCase {
 	/**
 	 *
 	 */
-	public function setUp() {
+	public function setUp(): void {
 		$this->Provider = new StdClass();
 
 		$Container = new Container();

--- a/tests/Essence/Provider/MetaTagsTest.php
+++ b/tests/Essence/Provider/MetaTagsTest.php
@@ -6,7 +6,7 @@
  */
 namespace Essence\Provider;
 
-use PHPUnit_Framework_TestCase as TestCase;
+use PHPUnit\Framework\TestCase as TestCase;
 use Essence\Dom\Document\Factory\Native as NativeDomDocument;
 use Essence\Http\Client\Native as NativeHttpClient;
 
@@ -27,7 +27,7 @@ class MetaTagsTest extends TestCase {
 	/**
 	 *
 	 */
-	public function setUp() {
+	public function setUp(): void {
 		$this->MetaTags = new MetaTags(
 			new NativeHttpClient(),
 			new NativeDomDocument()
@@ -56,7 +56,7 @@ class MetaTagsTest extends TestCase {
 	 *
 	 */
 	public function testExtractNothing() {
-		$this->setExpectedException('Exception');
+		$this->expectException('Exception');
 
 		$this->MetaTags->setMetaPattern('~nothing~');
 		$this->MetaTags->extract(

--- a/tests/Essence/Provider/OEmbed/ConfigTest.php
+++ b/tests/Essence/Provider/OEmbed/ConfigTest.php
@@ -6,7 +6,7 @@
  */
 namespace Essence\Provider\OEmbed;
 
-use PHPUnit_Framework_TestCase as TestCase;
+use PHPUnit\Framework\TestCase as TestCase;
 
 
 
@@ -25,7 +25,7 @@ class ConfigTest extends TestCase {
 	/**
 	 *
 	 */
-	public function setUp() {
+	public function setUp(): void {
 		$this->Config = new Config();
 	}
 

--- a/tests/Essence/Provider/OEmbedTest.php
+++ b/tests/Essence/Provider/OEmbedTest.php
@@ -6,7 +6,7 @@
  */
 namespace Essence\Provider;
 
-use PHPUnit_Framework_TestCase as TestCase;
+use PHPUnit\Framework\TestCase as TestCase;
 use Essence\Provider\OEmbed\Format;
 use Essence\Dom\Document\Factory\Native as NativeDomDocument;
 use Essence\Http\Client\Native as NativeHttpClient;
@@ -28,7 +28,7 @@ class OEmbedTest extends TestCase {
 	/**
 	 *
 	 */
-	public function setup() {
+	public function setUp(): void {
 		$this->OEmbed = new OEmbed(
 			new NativeHttpClient(),
 			new NativeDomDocument()
@@ -52,7 +52,7 @@ class OEmbedTest extends TestCase {
 	 *
 	 */
 	public function testExtractInvalidJson() {
-		$this->setExpectedException('Exception');
+		$this->expectException('Exception');
 		$this->OEmbed->extract('invalid');
 	}
 
@@ -77,7 +77,7 @@ class OEmbedTest extends TestCase {
 		$this->OEmbed->setEndpoint('file://' . ESSENCE_HTTP . ':url.xml');
 		$this->OEmbed->setFormat(Format::xml);
 
-		$this->setExpectedException('Exception');
+		$this->expectException('Exception');
 		$this->OEmbed->extract('invalid');
 	}
 
@@ -89,7 +89,7 @@ class OEmbedTest extends TestCase {
 	public function testExtractUnsupportedFormat() {
 		$this->OEmbed->setFormat('unsupported');
 
-		$this->setExpectedException('Exception');
+		$this->expectException('Exception');
 		$this->OEmbed->extract('valid');
 	}
 

--- a/tests/Essence/Provider/Preparator/RefactorerTest.php
+++ b/tests/Essence/Provider/Preparator/RefactorerTest.php
@@ -6,7 +6,7 @@
  */
 namespace Essence\Provider\Preparator;
 
-use PHPUnit_Framework_TestCase as TestCase;
+use PHPUnit\Framework\TestCase as TestCase;
 
 
 
@@ -25,7 +25,7 @@ class RefactorerTest extends TestCase {
 	/**
 	 *
 	 */
-	public function setUp() {
+	public function setUp(): void {
 		$this->Refactorer = new Refactorer(
 			'#player\.vimeo\.com/video/(?<id>[0-9]+)#i',
 			'http://www.vimeo.com/:id'

--- a/tests/Essence/Provider/PreparatorTest.php
+++ b/tests/Essence/Provider/PreparatorTest.php
@@ -6,7 +6,7 @@
  */
 namespace Essence\Provider;
 
-use PHPUnit_Framework_TestCase as TestCase;
+use PHPUnit\Framework\TestCase as TestCase;
 
 
 

--- a/tests/Essence/Provider/Presenter/CompleterTest.php
+++ b/tests/Essence/Provider/Presenter/CompleterTest.php
@@ -6,7 +6,7 @@
  */
 namespace Essence\Provider\Presenter;
 
-use PHPUnit_Framework_TestCase as TestCase;
+use PHPUnit\Framework\TestCase as TestCase;
 use Essence\Media;
 
 
@@ -26,7 +26,7 @@ class CompleterTest extends TestCase {
 	/**
 	 *
 	 */
-	public function setUp() {
+	public function setUp(): void {
 		$this->Completer = new Completer([
 			'foo' => 'bar'
 		]);

--- a/tests/Essence/Provider/Presenter/ReindexerTest.php
+++ b/tests/Essence/Provider/Presenter/ReindexerTest.php
@@ -6,7 +6,7 @@
  */
 namespace Essence\Provider\Presenter;
 
-use PHPUnit_Framework_TestCase as TestCase;
+use PHPUnit\Framework\TestCase as TestCase;
 use Essence\Media;
 
 
@@ -26,7 +26,7 @@ class ReindexerTest extends TestCase {
 	/**
 	 *
 	 */
-	public function setUp() {
+	public function setUp(): void {
 		$this->Reindexer = new Reindexer([
 			'old' => 'new'
 		]);

--- a/tests/Essence/Provider/Presenter/TemplaterTest.php
+++ b/tests/Essence/Provider/Presenter/TemplaterTest.php
@@ -6,7 +6,7 @@
  */
 namespace Essence\Provider\Presenter;
 
-use PHPUnit_Framework_TestCase as TestCase;
+use PHPUnit\Framework\TestCase as TestCase;
 use Essence\Media;
 
 
@@ -26,7 +26,7 @@ class TemplaterTest extends TestCase {
 	/**
 	 *
 	 */
-	public function setUp() {
+	public function setUp(): void {
 		$this->Templater = new Templater('html', 'type', [
 			'#foo#' => ':url',
 			'#.*#' => 'default'

--- a/tests/Essence/Provider/Presenter/YoutubeTest.php
+++ b/tests/Essence/Provider/Presenter/YoutubeTest.php
@@ -6,7 +6,7 @@
  */
 namespace Essence\Provider\Presenter;
 
-use PHPUnit_Framework_TestCase as TestCase;
+use PHPUnit\Framework\TestCase as TestCase;
 use Essence\Media;
 
 
@@ -26,7 +26,7 @@ class YoutubeTest extends TestCase {
 	/**
 	 *
 	 */
-	public function setup() {
+	public function setUp(): void {
 		$this->Media = new Media([
 			'thumbnailUrl' => 'http://i1.ytimg.com/vi/5jmjBXoyugM/hqdefault.jpg'
 		]);

--- a/tests/Essence/Provider/PresenterTest.php
+++ b/tests/Essence/Provider/PresenterTest.php
@@ -6,7 +6,7 @@
  */
 namespace Essence\Provider;
 
-use PHPUnit_Framework_TestCase as TestCase;
+use PHPUnit\Framework\TestCase as TestCase;
 use Essence\Media;
 
 

--- a/tests/Essence/ProviderTest.php
+++ b/tests/Essence/ProviderTest.php
@@ -6,7 +6,7 @@
  */
 namespace Essence;
 
-use PHPUnit_Framework_TestCase as TestCase;
+use PHPUnit\Framework\TestCase as TestCase;
 
 
 
@@ -26,7 +26,7 @@ class ProviderTest extends TestCase {
 	/**
 	 *
 	 */
-	public function setup() {
+	public function setUp(): void {
 		$this->Media = new Media([
 			'url' => 'http://foo.bar.com/resource',
 			'title' => 'Title',

--- a/tests/Essence/ReplacerTest.php
+++ b/tests/Essence/ReplacerTest.php
@@ -6,7 +6,7 @@
  */
 namespace Essence;
 
-use PHPUnit_Framework_TestCase as TestCase;
+use PHPUnit\Framework\TestCase as TestCase;
 use Essence\Di\Container\Standard as StandardContainer;
 
 
@@ -26,7 +26,7 @@ class ReplacerTest extends TestCase {
 	/**
 	 *
 	 */
-	public function setUp() {
+	public function setUp(): void {
 		$Media = new Media([
 			'title' => 'Title',
 			'html' => 'HTML'

--- a/tests/Essence/Utility/JsonTest.php
+++ b/tests/Essence/Utility/JsonTest.php
@@ -6,7 +6,7 @@
  */
 namespace Essence\Utility;
 
-use PHPUnit_Framework_TestCase as TestCase;
+use PHPUnit\Framework\TestCase as TestCase;
 
 
 
@@ -52,7 +52,7 @@ VALID;
 	 *
 	 */
 	public function testParseInvalid() {
-		$this->setExpectedException('Exception');
+		$this->expectException('Exception');
 		Json::parse($this->invalid);
 	}
 }

--- a/tests/Essence/Utility/TemplateTest.php
+++ b/tests/Essence/Utility/TemplateTest.php
@@ -6,7 +6,7 @@
  */
 namespace Essence\Utility;
 
-use PHPUnit_Framework_TestCase as TestCase;
+use PHPUnit\Framework\TestCase as TestCase;
 
 
 

--- a/tests/Essence/Utility/UrlTest.php
+++ b/tests/Essence/Utility/UrlTest.php
@@ -6,7 +6,7 @@
  */
 namespace Essence\Utility;
 
-use PHPUnit_Framework_TestCase as TestCase;
+use PHPUnit\Framework\TestCase as TestCase;
 
 
 

--- a/tests/Essence/Utility/XmlTest.php
+++ b/tests/Essence/Utility/XmlTest.php
@@ -6,7 +6,7 @@
  */
 namespace Essence\Utility;
 
-use PHPUnit_Framework_TestCase as TestCase;
+use PHPUnit\Framework\TestCase as TestCase;
 
 
 
@@ -53,7 +53,7 @@ class XmlTest extends TestCase {
 	 *
 	 */
 	public function testParseInvalid() {
-		$this->setExpectedException('Exception');
+		$this->expectException('Exception');
 		Xml::parse($this->invalid);
 	}
 }

--- a/tests/e2e/ProvidersTest.php
+++ b/tests/e2e/ProvidersTest.php
@@ -4,7 +4,7 @@
  *	@author Félix Girault <felix.girault@gmail.com>
  *	@license FreeBSD License (http://opensource.org/licenses/BSD-2-Clause)
  */
-use PHPUnit_Framework_TestCase as TestCase;
+use PHPUnit\Framework\TestCase as TestCase;
 use Essence\Essence;
 
 
@@ -24,7 +24,7 @@ class ProvidersTest extends TestCase {
 	/**
 	 *
 	 */
-	public function setUp() {
+	public function setUp(): void {
 		$this->Essence = new Essence();
 	}
 


### PR DESCRIPTION
Hi @felixgirault,

As we discussed in #153 I prepared two patches for upgrading essence to be compatible with >=PHP 8.0.

Tests are working but they are still failing. I didn't change anything in the logic of the tests.